### PR TITLE
Fix readVarInt length calculation causing unintended type coercion

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1445,7 +1445,7 @@ function readVarInt(buffer, offset) {
   var cursor = offset;
     
   while (true) {
-    if (cursor + 1 > buffer) return null;
+    if (cursor + 1 > buffer.length) return null;
     var b = buffer.readUInt8(cursor);
     result |= ((b & 0x7f) << shift); // Add the bits to our number, except MSB
     cursor++;


### PR DESCRIPTION
Tracked this down while seeing performance issues parsing packets, 68% of the time was spent in readVarInt (coercing the buffer to a string), with the fix only 0.04% :)
